### PR TITLE
prove 2+2 = 4

### DIFF
--- a/metamath/realtwoplustwo.mm
+++ b/metamath/realtwoplustwo.mm
@@ -1,3 +1,174 @@
-$[ lib/peano.mm $]
+$[ twoplustwo.mm $]
 
-2p2e4 $a |- = + S S 0 S S 0 S S S S 0 $.
+$(
+  We're going to replicate most of the work done for one_ne_zero
+  for the other axioms, so that we can have terms instead of vars.
+$)
+
+${
+  $( phi |- A. x phi $)
+  gen.1 $e |- phi $.
+  $( This is an axiom in set.mm, but here it has a (somewhat convoluted) proof. $)
+  gen $p |- forall x phi $=
+    ( quant_all tzero binpred_equals wff_quant eq-refl eq-sym ax-mp logbinopiff
+    wff_atom alpha_2 wff_logbinop logbinopimplies ax-1 bi3 alpha_1 bi1 ) ADEEFL
+    ZGZADBGZTUAEHZATTEEIMJKUBUANZOUBUANTUDUCADTTBKBTNZOUETNOTBNZUETUFUCTBPJOBTN
+    ZOUEUFNBUGCBTPJTBQJJUETPJRJUAUBSJJ $.
+$}
+
+${
+  $d x psi $.  $d x t $.
+  $( x = t -> (A <-> B), A |- B $)
+  var_to_term.1 $e |- implies = x t iff phi psi $.
+  var_to_term.2 $e |- phi $.
+  $(
+    This is the main theorem needed for the var/term transformations.
+    In set.mm it's called vtocl for "var to class", but here it's more
+    like var to term.
+  $)
+  var_to_term $p |- psi $=
+    ( quant_all logbinopimplies tvar binpred_equals wff_atom wff_quant all_elim
+    wff_logbinop gen ax-mp all_elim3 ) BGHCBIAJKNLZDBGCLRBCFOABCMPABCDEQP $.
+$}
+
+$( Oops, ran out of variables. let's make some new wffs. $)
+$v psi2 chi2 $.
+wpsi2 $f wff psi2 $.
+wchi2 $f wff chi2 $.
+
+biid $p |- iff phi phi $=
+  ( logbinopimplies wff_logbinop logbinopiff id bi3 ax-mp ) BAACZDAACZAEZHBIHC
+  JAAFGG $.
+
+biidd $p |- implies phi iff psi psi $=
+  ( logbinopiff wff_logbinop logbinopimplies biid ax-1 ax-mp ) CBBDZEIADBFIAGH
+  $.
+
+eqidd $p |- implies phi = t t $=
+  ( binpred_equals wff_atom logbinopimplies wff_logbinop eq-refl ax-1 ax-mp )
+  AACDZEJBFAGJBHI $.
+
+eqeq1 $p |- implies = s t iff = s u = t u $=
+  ( wff_atom logbinopimplies wff_logbinop logbinopiff eq-trans logbinopand
+  andL binpred_equals exp eq-sym syl andR andId bi3 mpd ) ABKDZEACKDZBCKDZFZGUA
+  TFZSUATABCHLSEUATFEUCUBFSTUAITSFZITBAKDZFUAUDUETUDSUESTJABMNSTOPBACHNLTUAQNR
+  $.
+
+${
+  $( A -> (B1 <-> B2), A -> (C1 <-> C2) |- A -> ((B1 -> C1) <-> (B2 -> C2)) $)
+  imbid.1 $e |- implies phi iff psi psi2 $.
+  imbid.2 $e |- implies phi iff chi chi2 $.
+  imbid $p |- implies phi iff implies psi chi implies psi2 chi2 $=
+    ( logbinopimplies wff_logbinop logbinopiff bi1 syl imim2 com12 bi2 mpd bi3
+    ) AHHCBIZHEDIZIZJSRIZAHHEBIZSIZTAHDBIZUCAJDBIZUDFBDKLSUDUBBDEMNLAHRUBIZHTUC
+    IAHCEIZUFAJECIZUGGCEOLBECMLSUBRMLPAHSRIZHUATIAHHCDIZRIZUIAHBDIZUKAUEULFBDOL
+    RULUJDBCMNLAHSUJIZHUIUKIAHECIZUMAUHUNGCEKLDCEMLRUJSMLPRSQLP $.
+$}
+
+${
+  $( A -> (B <-> C), A -> (C <-> D) |- A -> (B <-> D) $)
+  bitrd.1 $e |- implies phi iff psi psi2 $.
+  bitrd.2 $e |- implies phi iff psi2 chi $.
+  bitrd $p |- implies phi iff psi chi $=
+    ( logbinopimplies wff_logbinop logbinopiff bi2 syl imim2 mpd bi1 bi3 ) AGBC
+    HZICBHZAGDCHZPAICDHZRFDCJKAGBDHZGPRHAIDBHZTEBDJKCDBLKMAGCBHZGQPHAGDBHZUBAUA
+    UCEBDNKAGCDHZGUBUCHASUDFDCNKBDCLKMBCOKM $.
+$}
+
+${
+  $( A -> (B <-> C) |- A -> (C <-> B) $)
+  bicomd.1 $e |- implies phi iff psi chi $.
+  bicomd $p |- implies phi iff chi psi $=
+    ( logbinopiff wff_logbinop logbinopimplies bi1 bi2 bi3 syl mpd ) AECBFZEBCF
+    ZDMGCBFZNBCHMGBCFGNOFBCICBJKLK $.
+$}
+
+${
+  $( A -> (B1 <-> B2), A -> (C1 <-> C2) |- A -> ((B1 <-> C1) <-> (B2 <-> C2)) $)
+  bibid.1 $e |- implies phi iff psi psi2 $.
+  bibid.2 $e |- implies phi iff chi chi2 $.
+  bibid $p |- implies phi iff iff psi chi iff psi2 chi2 $=
+    ( logbinopimplies logbinopiff wff_logbinop logbinopand andL syl andR bicomd
+    bitrd exp bi3 mpd ) AHICBJZIEDJZJZIUATJZAUATKUAAJZBCDUDAIDBJZAUALZFMUDDCEAU
+    ANUDCEUDAIECJZUFGMOPPQAHUATJHUCUBJATUAKTAJZDEBUHBDUHAUEATLZFMOUHBECATNUHAUG
+    UIGMPPQTUARMS $.
+$}
+
+${
+  $d x y z s $.  $d x y z t $.  $d x y u $.
+  $( 0 != S t $)
+  pa_ax1_term $p |- not = 0 S t $=
+    ( tzero tsucc binpred_equals wff_atom wff_not logbinopiff wff_logbinop
+    eq-suc varx tvar eqeq2 syl notbi pa_ax1 var_to_term ) AJBJKZCZDEZFZBACZDEZFZQ
+    ADEZGUBSHZGUCTHUDRUADEUEQAIRUABLMSUBNMJOP $.
+
+  $( S s = S t -> s = t $)
+  pa_ax2_term $p |- implies = S s S t = s t $=
+    ( vary logbinopimplies binpred_equals wff_atom tsucc wff_logbinop
+    logbinopiff varx tvar eq-suc eqeq2 syl imbid eqeq1 pa_ax2 var_to_term ) BCDAC
+    KZEFZAGZSGZEFZHZDABEFZUABGZEFZHSBEFZUCTUGUEUHUBUFEFIUGUCHSBLUBUFUAMNSBAMOAJDJ
+    KZSEFZUIGZUBEFZHUDUIAEFZULUJUCTUMUKUAEFIUCULHUIALUKUAUBPNUIASPOJCQRR $.
+
+  $( s + 0 = s $)
+  pa_ax3_term $p |- = + s 0 s $=
+    ( varx tzero binop_plus tbinop binpred_equals wff_atom tvar eqeq1
+    logbinopiff wff_logbinop logbinopand id logbinopimplies eq-refl ax-1 ax-mp
+    andId eq-binop syl eqeq2 bitrd pa_ax3 var_to_term eq-sym ) AACDEZFGZUFAFGABBH
+    ZUHCDEZFGZUGUHAFGZUJUGAUIFGZUHAUIIUKUIUFFGZJUGULKUKLCCFGZUKKUMUKUKUNUKMUNNUNU
+    KKCOUNUKPQRUHACCDSTUIUFAUATUBBUCUDAUFUEQ $.
+
+  $( s + S t = S (s + t) $)
+  pa_ax4_term $p |- = + s S t S + s t $=
+    ( vary varx binop_plus tbinop tsucc binpred_equals wff_atom tvar
+    wff_logbinop logbinopiff logbinopand eqidd id andId eq-binop syl eq-suc eqeq1
+    eqeq2 pa_ax4 bitrd var_to_term eq-sym ax-mp ) ABEFZGZABGZEFZHIZUJUHHIBCACJZEF
+    ZGZAULGZEFZHIZUKULBHIZUQUKUHUPHIZURUNUHHIZLUSUQKURUMUGHIZUTURMURAAHIZKVAURVBU
+    RAURNZUROPAAULBEQRUMUGSRUNUHUPTRURUPUJHIZLUKUSKURMUOUIHIZVBKVDURVBVEVCULBSPAA
+    UOUIEQRUPUJUHUARUCADDJZULEFZGZVFUOEFZHIZUQVFAHIZVJUQUNVIHIZVKVHUNHIZLVLVJKVKV
+    GUMHIZVMVKMULULHIZVKKVNVKVKVOVKOZULVKNPVFAULULEQRVGUMSRVHUNVITRVKVIUPHIZLUQVL
+    KVKMUOUOHIZVKKVQVKVKVRVPUOVKNPVFAUOUOEQRVIUPUNUARUCDCUBUDUDUHUJUEUF $.
+
+  $( s * 0 = 0 $)
+  pa_ax5_term $p |- = * t 0 0 $=
+    ( varx tzero binop_times binpred_equals wff_atom tvar logbinopiff
+    logbinopand tbinop wff_logbinop eqidd andId eq-binop syl eqeq2 pa_ax5
+    var_to_term eq-sym id ax-mp ) CACDJZEFZUBCEFABCBGZCDJZEFZUCUDAEFZUEUBEFZHUCUF
+    KUGICCEFZUGKUHUGUGUIUGTCUGLMUDACCDNOUEUBCPOBQRCUBSUA $.
+
+  $( s * S t = s * t + s $)
+  pa_ax6_term $p |- = * s S t + * s t s $=
+    ( vary varx binop_times tbinop binop_plus binpred_equals wff_atom
+    logbinopiff tsucc tvar wff_logbinop logbinopand eqidd id andId eq-binop syl
+    eqeq1 eq-suc eqeq2 bitrd pa_ax6 var_to_term eq-sym ax-mp ) ABEFZAGFZABKZEFZHI
+    ZUKUIHIBCACLZEFZAGFZAUMKZEFZHIZULUMBHIZURULUIUQHIZUSUOUIHIZJUTURMUSNAAHIZUNUH
+    HIZMVAUSVCVBUSNUSVBMVCUSVBUSAUSOZUSPQAAUMBERSVDQUNUHAAGRSUOUIUQTSUSUQUKHIZJUL
+    UTMUSNUPUJHIZVBMVEUSVBVFVDUMBUAQAAUPUJERSUQUKUIUBSUCADDLZUMEFZVGGFZVGUPEFZHIZ
+    URVGAHIZVKURUOVJHIZVLVIUOHIZJVMVKMVLNVLVHUNHIZMVNVLVOVLVLNUMUMHIZVLMVOVLVLVPV
+    LPZUMVLOQVGAUMUMERSVQQVHUNVGAGRSVIUOVJTSVLVJUQHIZJURVMMVLNUPUPHIZVLMVRVLVLVSV
+    QUPVLOQVGAUPUPERSVJUQUOUBSUCDCUDUEUEUIUKUFUG $.
+
+  $( s < t <-> (E. x, t = s + S x) $)
+  pa_ax7_term $p |- iff < s t exists x = t + s S x $=
+    ( varz vary logbinopiff quant_ex binop_plus binpred_equals wff_atom
+    wff_quant tvar tbinop binpred_less_than wff_logbinop logbinopand eqidd id
+    andId syl tsucc eq-congr eqeq1 alpha_1 bibid eq-binop eqeq2 pa_ax7
+    var_to_term ) BDFCGDLZACLUAZHMZIJZKZAUJNJZOZFCGBULIJZKZABNJZOUJBIJZUOUNUSURUT
+    PUTAAIJZOFUSUOOUTVAUTAUTQUTRSAAUJBNUBTCGUTUMUQUJBULUCUDUEAEFCGUJELZUKHMZIJZKZ
+    VBUJNJZOUPVBAIJZVFVEUOUNVGPUJUJIJZVGOFUOVFOVGVGVHVGRZUJVGQSVBAUJUJNUBTCGVGVDU
+    MVGVCULIJZFUMVDOVGPUKUKIJZVGOVJVGVGVKVIUKVGQSVBAUKUKHUFTVCULUJUGTUDUEEDCUHUIU
+    I $.
+$}
+
+${
+  $( A -> (B1 <-> B2), A -> (C1 <-> C2) |- A -> ((B1 <-> C1) <-> (B2 <-> C2)) $)
+  eqtri.1 $e |- = s t $.
+  eqtri.2 $e |- = t u $.
+  eqtri $p |- = s u $=
+    ( logbinopand binpred_equals wff_atom wff_logbinop logbinopimplies eq-trans
+    andI ax-mp ) FBCGHZABGHZIZACGHNPEOJPNIDONLMMABCKM $.
+$}
+
+2p2e4 $p |- = + S S 0 S S 0 S S S S 0 $=
+  ( tzero tsucc binop_plus tbinop pa_ax4_term binpred_equals pa_ax3_term
+  eq-suc wff_atom ax-mp eqtri ) ABZBZMCDMLCDZBZMBZBZMLENPFIOQFINMACDZBZPMAERMFI
+  SPFIMGRMHJKNPHJK $.

--- a/metamath/twoplustwo.mm
+++ b/metamath/twoplustwo.mm
@@ -1,5 +1,140 @@
 $[ lib/peano.mm $]
 
+$(
+  Doing this sort of thing from the bottom on stream is an impressive undertaking.
+  Unfortunately, there are a bunch of prerequisites needed to really get anywhere
+  starting from just the axioms, and propositional logic is a big one. In order to
+  have a good time using propositional logic, you need a library of ~200 basic
+  theorems in propositional logic. I will not do this, but instead just prove a few
+  requirements for the theorems of interest today.
+
+  These proofs are primarily borrowed from peano.mm1, which were themselves borrowed
+  from set.mm proofs. -Mario
+$)
+
+${
+  mpd.1 $e |- implies phi psi $.
+  mpd.2 $e |- implies phi implies psi chi $.
+  $( A -> B, A -> B -> C |- A -> C $)
+  mpd $p |- implies phi chi $=
+    ( logbinopimplies wff_logbinop ax-2 ax-mp ) FBAGZFCAGZDFFCBGAGFKJGEABCHII
+    $.
+$}
+
+${
+  syl.1 $e |- implies phi psi $.
+  syl.2 $e |- implies psi chi $.
+  $( A -> B, B -> C |- A -> C $)
+  syl $p |- implies phi chi $=
+    ( logbinopimplies wff_logbinop ax-1 ax-mp mpd ) ABCDFCBGZFKAGEKAHIJ $.
+$}
+
+$( A -> A $)
+id $p |- implies phi phi $=
+  ( logbinopimplies wff_logbinop ax-1 mpd ) ABAACZAAADAFDE $.
+
+$( !A -> A -> B $)
+absurd $p |- implies not phi implies phi psi $=
+  ( wff_not logbinopimplies wff_logbinop ax-1 ax-3 syl ) ACZDIBCZEDBAEIJFBAGH
+  $.
+
+${
+  com12.1 $e |- implies phi implies psi chi $.
+  $( A -> B -> C |- B -> A -> C $)
+  com12 $p |- implies psi implies phi chi $=
+    ( logbinopimplies wff_logbinop ax-1 ax-2 ax-mp syl ) BEBAFZECAFZBAGEECBFAFE
+    LKFDABCHIJ $.
+$}
+
+${
+  imidm.1 $e |- implies phi implies phi psi $.
+  $( A -> A -> B |- A -> B $)
+  imidm $p |- implies phi psi $=
+    ( logbinopimplies wff_logbinop id com12 mpd ) ADBAEZBCIABIFGH $.
+$}
+
+$( (!A -> A) -> A $)
+contra $p |- implies implies not phi phi phi $=
+  ( logbinopimplies wff_not wff_logbinop absurd ax-2 ax-mp ax-3 syl imidm ) BA
+  ACZDZALBLCZKDZBALDBBMADKDBNLDAMEKAMFGALHIJ $.
+
+$( !!A -> A $)
+notnot2 $p |- implies not not phi phi $=
+  ( wff_not logbinopimplies wff_logbinop absurd contra syl ) ABZBCAHDAHAEAFG
+  $.
+
+$( (B -> C) -> (A -> B) -> (A -> C) $)
+imim2 $p |- implies implies psi chi
+            implies implies phi psi
+                    implies phi chi $=
+  ( logbinopimplies wff_logbinop ax-1 ax-2 syl ) DCBEZDIAEDDCAEDBAEEIAFABCGH
+  $.
+
+$( (A -> !B) -> (B -> !A) $)
+con2 $p |- implies implies phi not psi
+                   implies psi not phi $=
+  ( logbinopimplies wff_not wff_logbinop notnot2 imim2 com12 ax-mp ax-3 syl )
+  CBDZAEZCLADZDZEZCNBECAOEZCPMEAFMQPOALGHINBJK $.
+
+$( A -> !!A $)
+notnot1 $p |- implies phi not not phi $=
+  ( logbinopimplies wff_not wff_logbinop id con2 ax-mp ) BACZHDBHCADHEHAFG $.
+
+${
+  con1i.1 $e |- implies not phi psi $.
+  $( !A -> B |- !B -> A $)
+  con1i $p |- implies not psi phi $=
+    ( logbinopimplies wff_not wff_logbinop notnot1 syl ax-3 ax-mp ) DBEZEZAEZFD
+    AKFMBLCBGHAKIJ $.
+$}
+
+$( (A -> B) -> (!B -> !A) $)
+con3 $p |- implies implies phi psi
+                   implies not psi not phi $=
+  ( logbinopimplies wff_logbinop wff_not notnot1 imim2 ax-mp con2 syl ) CBADZC
+  BEZEZADZCAELDCMBDCNKDBFABMGHALIJ $.
+
+$( A /\ B -> A $)
+andL $p |- implies and phi psi phi $=
+  ( logbinopand wff_logbinop logbinopimplies logbinopiff df-an bi1 ax-mp
+  absurd wff_not con1i syl ) CBADZEBKZADZKZAFQNDEQNDABGNQHIAPAOJLM $.
+
+$( A /\ B -> B $)
+andR $p |- implies and phi psi psi $=
+  ( logbinopand wff_logbinop logbinopimplies wff_not logbinopiff df-an bi1
+  ax-1 ax-mp con1i syl ) CBADZEBFZADZFZBGQNDEQNDABHNQIKBPOAJLM $.
+
+$( A -> B -> A /\ B $)
+andI $p |- implies phi implies psi and phi psi $=
+  ( logbinopimplies wff_not wff_logbinop logbinopand com12 con2 syl
+  logbinopiff id df-an bi2 ax-mp imim2 ) ACCBDZAEZDZBEZCFBAEZBEZACPQESQAPQKGQBH
+  ICTREZCUASEJRTEUBABLTRMNBRTONI $.
+
+${
+  andId.1 $e |- implies phi psi $.
+  andId.2 $e |- implies phi chi $.
+  $( A -> B -> A /\ B $)
+  andId $p |- implies phi and psi chi $=
+    ( logbinopand wff_logbinop logbinopimplies andI syl mpd ) ACFCBGZEABHLCGDBC
+    IJK $.
+$}
+
+${
+  imp.1 $e |- implies phi implies psi chi $.
+  $( A -> B -> C |- A /\ B -> C $)
+  imp $p |- implies and phi psi chi $=
+    ( logbinopand wff_logbinop andR logbinopimplies andL syl mpd ) EBAFZBCABGLA
+    HCBFABIDJK $.
+$}
+
+${
+  exp.1 $e |- implies and phi psi chi $.
+  $( A /\ B -> C |- A -> B -> C $)
+  exp $p |- implies phi implies psi chi $=
+    ( logbinopimplies logbinopand wff_logbinop andI imim2 ax-mp syl ) AEFBAGZBG
+    ZECBGZABHECLGENMGDBLCIJK $.
+$}
+
 wff_pa_ax1 $p wff not = 0 S x $=
   tzero varx tvar tsucc binpred_equals wff_atom wff_not
 $.
@@ -101,7 +236,15 @@ tmp3b $p |- implies and = 0 0 = S x S 0 iff = 0 S x = 0 S 0 $=
   eq-congr
 $.
 
-tmp3c $a |- implies = S x S 0 and = 0 0 = S x S 0 $.
+tmp3c $p |- implies = S x S 0 and = 0 0 = S x S 0 $=
+  ( tzero binpred_equals wff_atom logbinopimplies logbinopand tvar
+  wff_logbinop tsucc eq-refl andI ax-mp ) BBCDZEFAGIBICDZMHNHBJMNKL $.
+
+eqeq2 $p |- implies = s t iff = u s = u t $=
+  ( binpred_equals wff_atom logbinopimplies logbinopiff logbinopand andR
+  eq-sym wff_logbinop andL syl andId eq-trans exp bi3 mpd ) ABDEZFCADEZCBDEZKZG
+  UATKZSUATHUASKZHBADEZUAKTUDUAUESUAIUDSUESUALABJMNCBAOMPSFUATKFUCUBKSTUAHTSKZH
+  STKUAUFTSSTISTLNCABOMPTUAQMR $.
 
 $(
   phi: = S x S 0
@@ -109,7 +252,8 @@ $(
   chi: iff = 0 S x = 0 S 0
 $)
 
-tmp3d $a |- implies = S x S 0 iff = 0 S x = 0 S 0 $.
+tmp3d $p |- implies = S x S 0 iff = 0 S x = 0 S 0 $=
+  ( tvar tsucc tzero eqeq2 ) ABCDCDE $.
 
 $(
   phi: = x 0
@@ -117,11 +261,19 @@ $(
   chi: iff = 0 S x = 0 S 0
 $)
 
-tmp3e $a |- implies = x 0 iff = 0 S x = 0 S 0 $.
+tmp3e $p |- implies = x 0 iff = 0 S x = 0 S 0 $=
+  ( tvar tzero binpred_equals wff_atom tsucc logbinopiff wff_logbinop tmp3d
+  syl eq-suc ) ABZCDELFZCFZDEGCNDECMDEHLCKAIJ $.
 
 $( using ax-3 $)
 
-tmp3f $a |- implies iff 0 S x = 0 S 0 iff not = 0 S x not = 0 S 0 $.
+$( (A <-> B) -> (!A <-> !B) $)
+notbi $p |- implies iff phi psi iff not phi not psi $=
+  ( logbinopiff wff_logbinop logbinopimplies wff_not bi1 con3 syl bi2 bi3 mpd
+  ) CBADZEAFZBFZDZCONDZMEBADPABGABHIMEONDZEQPDMEABDRABJBAHINOKIL $.
+
+tmp3f $p |- implies iff = 0 S x = 0 S 0 iff not = 0 S x not = 0 S 0 $=
+  ( tzero tvar tsucc binpred_equals wff_atom notbi ) BACDEFBBDEFG $.
 
 $(
   phi: = x 0
@@ -131,7 +283,9 @@ $(
   psi -> chi = tmp3f
 $)
 
-cheat3 $a |- implies = x 0 iff not = 0 S x not = 0 S 0 $.
+cheat3 $p |- implies = x 0 iff not = 0 S x not = 0 S 0 $=
+  ( tvar tzero binpred_equals wff_atom logbinopiff tsucc wff_logbinop tmp3e
+  syl wff_not tmp3f ) ABZCDEFCCGDEZCMGDEZHFNKOKHAIALJ $.
 
 $( t,x,phi,chi,all_elim3_hyp1 $)
 nocheat4 $p |- implies


### PR DESCRIPTION
Hi George, I'm Mario Carneiro. I'm a Metamath contributor, maintainer of the mmj2 proof assistant / IDE for metamath, and author of Metamath Zero (which, as you identified, tries to address some of the syntax issues in metamath). I watched your streams and I was very impressed with your efforts to work with the peano.mm database, and you got so close, but I think the fact that peano.mm has no theorems in it really hurt you, because you had no template to work from. With that in mind, here's a complete proof of 2p2e4 (no cheats). You will notice that most of the work is actually propositional logic; this can be copied and pasted from other mm databases, modulo conversion to polish notation.

The key theorem that you missed in the stream was what I've called `var_to_term`. The text of peano.mm tries to explain this but it doesn't do a great job of it and in particular it doesn't prove any of the requisite theorems, only saying such and such is easy. It is easy, but only after you have a lot of experience with this propositional logic stuff (and metamath itself).

You may wonder how these proofs were written. I can assure you, I *never* write syntax proofs (i.e. `tzero tsucc tsucc` for `S S 0`). These are automated to oblivion by every self-respecting metamath proof assistant. I used MMJ2 for these proofs. (I am sorry about your installation issues, but I don't have a Mac to test; please make a PR if you needed to modify the scripts to make them work on your installation.)

Please contact me or @nmegill, or ask questions on the [Google group](https://groups.google.com/forum/#!forum/metamath) if you are still interested in these matters. It's very active, and our SEO is not that great (as you noticed) because the community is pretty small, so it's best to just ask someone directly and we would be happy to help. There is a recent [thread](https://groups.google.com/forum/#!topic/metamath/XPYuatviNV0) about your stream series, and we would welcome your participation.